### PR TITLE
chore: rename different object and procedure to be more accurate

### DIFF
--- a/tests/teststun.nim
+++ b/tests/teststun.nim
@@ -11,7 +11,7 @@
 
 import options
 import bearssl
-import ../webrtc/udp_connection
+import ../webrtc/udp_transport
 import ../webrtc/stun/stun_connection
 import ../webrtc/stun/stun_message
 import ../webrtc/stun/stun_attributes
@@ -30,9 +30,9 @@ proc passwordProvTest(username: seq[byte]): seq[byte] {.raises: [], gcsafe.} = @
 suite "Stun message encoding/decoding":
   test "Get BindingRequest + encode & decode with a set username":
     var
-      udpConn = UdpConn.init(AnyAddress)
+      udp = UdpTransport.new(AnyAddress)
       conn = StunConn.new(
-        udpConn,
+        udp,
         TransportAddress(AnyAddress),
         iceControlling=true,
         usernameProvider=usernameProvTest,
@@ -55,9 +55,9 @@ suite "Stun message encoding/decoding":
 
   test "Get BindingResponse from BindingRequest + encode & decode":
     var
-      udpConn = UdpConn.init(AnyAddress)
+      udp = UdpTransport.new(AnyAddress)
       conn = StunConn.new(
-        udpConn,
+        udp,
         TransportAddress(AnyAddress),
         iceControlling=false,
         usernameProvider=usernameProvTest,
@@ -81,9 +81,9 @@ suite "Stun message encoding/decoding":
 suite "Stun checkForError":
   test "checkForError: Missing MessageIntegrity or Username":
     var
-      udpConn = UdpConn.init(AnyAddress)
+      udp = UdpTransport.new(AnyAddress)
       conn = StunConn.new(
-        udpConn,
+        udp,
         TransportAddress(AnyAddress),
         iceControlling=false,
         usernameProvider=usernameProvEmpty, # Use of an empty username provider
@@ -107,9 +107,9 @@ suite "Stun checkForError":
 
   test "checkForError: UsernameChecker returns false":
     var
-      udpConn = UdpConn.init(AnyAddress)
+      udp = UdpTransport.new(AnyAddress)
       conn = StunConn.new(
-        udpConn,
+        udp,
         TransportAddress(AnyAddress),
         iceControlling=false,
         usernameProvider=usernameProvTest,

--- a/webrtc/stun/stun_attributes.nim
+++ b/webrtc/stun/stun_attributes.nim
@@ -13,10 +13,9 @@ import binary_serialization,
        chronos
 import stun_utils
 
-# -- Attributes --
-# There are obviously some attributes implementation that are missing,
-# it might be something to do eventually if we want to make this
-# repository work for other project than nim-libp2p
+# Some attributes implementation are missing, it might be something to
+# add eventually if we want to make this repository work for
+# other project than nim-libp2p.
 #
 # Stun Attribute
 # 0                   1                   2                   3


### PR DESCRIPTION
- Rename UdpConn into UdpTransport. UdpConn is confusing, as it is not a connection. To be perfectly honest, UdpTransport should probably be merged into StunTransport at some point. But it's not urgent or critical or even necessary, it would just be a neat addition.
- Rename UdpTransport.init into UdpTransport.new as it's initializing a reference object.