### PR TITLE
chore: update ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,15 +25,15 @@ jobs:
         include:
           - target:
               os: linux
-            builder: ubuntu-20.04
+            builder: ubuntu-22.04
             shell: bash
           - target:
               os: macos
-            builder: macos-12
+            builder: macos-13
             shell: bash
           - target:
               os: windows
-            builder: windows-2019
+            builder: windows-2022
             shell: msys2 {0}
 
     defaults:


### PR DESCRIPTION
Linux CI is currently failing with this error:
```
/tmp/choosenim-0.8.5_linux_amd64: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /tmp/choosenim-0.8.5_linux_amd64)
/tmp/choosenim-0.8.5_linux_amd64: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /tmp/choosenim-0.8.5_linux_amd64)
```