### PR TITLE
fix: stun and dtls close

### DIFF
--- a/tests/testdtls.nim
+++ b/tests/testdtls.nim
@@ -103,7 +103,7 @@ suite "DTLS":
     check (await serverConn.read()) == @[5'u8, 6, 7, 8]
     check (await clientConn.read()) == @[1'u8, 2, 3, 4]
     await allFutures(serverConn.close(), clientConn.close())
-    check serverConn.closed and clientConn.closed
+    check serverConn.isClosed() and clientConn.isClosed()
 
     serverConnFut = dtls1.accept()
     clientConn = await dtls2.connect(localAddr1)

--- a/webrtc/dtls/dtls_connection.nim
+++ b/webrtc/dtls/dtls_connection.nim
@@ -56,6 +56,9 @@ type
     # Mbed-TLS contexts
     ctx: MbedTLSCtx
 
+proc isClosed*(self: DtlsConn): bool =
+  return self.closed
+
 proc getRemoteCertificateCallback(
     ctx: pointer, pcert: ptr mbedtls_x509_crt, state: cint, pflags: ptr uint32
 ): cint {.cdecl.} =

--- a/webrtc/dtls/dtls_transport.nim
+++ b/webrtc/dtls/dtls_transport.nim
@@ -83,7 +83,7 @@ proc addConnToTable(self: Dtls, conn: DtlsConn) =
   proc cleanup() =
     self.connections.del(conn.remoteAddress())
   self.connections[conn.remoteAddress()] = conn
-  conn.cleanup = cleanup
+  conn.addOnClose(cleanup)
 
 proc accept*(
     self: Dtls

--- a/webrtc/dtls/dtls_transport.nim
+++ b/webrtc/dtls/dtls_transport.nim
@@ -28,12 +28,8 @@ logScope:
 const DtlsTransportTracker* = "webrtc.dtls.transport"
 
 type
-  DtlsConnAndCleanup = object
-    connection: DtlsConn
-    cleanup: Future[void].Raising([])
-
   Dtls* = ref object of RootObj
-    connections: Table[TransportAddress, DtlsConnAndCleanup]
+    connections: Table[TransportAddress, DtlsConn]
     transport: Stun
     laddr: TransportAddress
     started: bool
@@ -46,7 +42,7 @@ type
 
 proc new*(T: type Dtls, transport: Stun): T =
   var self = T(
-    connections: initTable[TransportAddress, DtlsConnAndCleanup](),
+    connections: initTable[TransportAddress, DtlsConn](),
     transport: transport,
     laddr: transport.laddr,
     started: true,
@@ -72,10 +68,8 @@ proc stop*(self: Dtls) {.async: (raises: [CancelledError]).} =
 
   self.started = false
   let
-    allCloses = toSeq(self.connections.values()).mapIt(it.connection.close())
-    allCleanup = toSeq(self.connections.values()).mapIt(it.cleanup)
+    allCloses = toSeq(self.connections.values()).mapIt(it.close())
   await noCancel allFutures(allCloses)
-  await noCancel allFutures(allCleanup)
   untrackCounter(DtlsTransportTracker)
 
 proc localCertificate*(self: Dtls): seq[byte] =
@@ -85,14 +79,11 @@ proc localCertificate*(self: Dtls): seq[byte] =
 proc localAddress*(self: Dtls): TransportAddress =
   self.laddr
 
-proc cleanupDtlsConn(self: Dtls, conn: DtlsConn) {.async: (raises: []).} =
-  # Waiting for a connection to be closed to remove it from the table
-  try:
-    await conn.join()
-  except CancelledError as exc:
-    discard
-
-  self.connections.del(conn.remoteAddress())
+proc addConnToTable(self: Dtls, conn: DtlsConn) =
+  proc cleanup() =
+    self.connections.del(conn.remoteAddress())
+  self.connections[conn.remoteAddress()] = conn
+  conn.cleanup = cleanup
 
 proc accept*(
     self: Dtls
@@ -114,8 +105,7 @@ proc accept*(
           self.ctr_drbg, self.serverPrivKey, self.serverCert, self.localCert
         )
         await res.dtlsHandshake(true)
-        self.connections[raddr] =
-          DtlsConnAndCleanup(connection: res, cleanup: self.cleanupDtlsConn(res))
+        self.addConnToTable(res)
         break
       except WebRtcError as exc:
         trace "Handshake fails, try accept another connection", raddr, error = exc.msg
@@ -136,8 +126,7 @@ proc connect*(
 
   try:
     await res.dtlsHandshake(false)
-    self.connections[raddr] =
-      DtlsConnAndCleanup(connection: res, cleanup: self.cleanupDtlsConn(res))
+    self.addConnToTable(res)
   except WebRtcError as exc:
     trace "Handshake fails", raddr, error = exc.msg
     self.connections.del(raddr)

--- a/webrtc/stun/stun_connection.nim
+++ b/webrtc/stun/stun_connection.nim
@@ -28,6 +28,7 @@ type
   StunUsernameProvider* = proc(): string {.raises: [], gcsafe.}
   StunUsernameChecker* = proc(username: seq[byte]): bool {.raises: [], gcsafe.}
   StunPasswordProvider* = proc(username: seq[byte]): seq[byte] {.raises: [], gcsafe.}
+  StunConnCleanup* = proc() {.raises: [], gcsafe.}
 
   StunConn* = ref object
     udp*: UdpTransport # The wrapper protocol: UDP Transport
@@ -37,8 +38,11 @@ type
     stunMsgs*: AsyncQueue[seq[byte]] # stun messages received and to be
                                      # processed by the stun message handler
     handlesFut*: Future[void] # Stun Message handler
+
+    # Close connection management
     closeEvent: AsyncEvent
     closed*: bool
+    cleanup*: StunConnCleanup
 
     # Is ice-controlling and iceTiebreaker, not fully implemented yet.
     iceControlling: bool
@@ -227,6 +231,9 @@ proc close*(self: StunConn) {.async: (raises: []).} =
     debug "Try to close an already closed StunConn"
     return
   await self.handlesFut.cancelAndWait()
+  if not self.cleanup.isNil():
+    self.cleanup()
+    self.cleanup = nil
   self.closeEvent.fire()
   self.closed = true
   untrackCounter(StunConnectionTracker)

--- a/webrtc/stun/stun_transport.nim
+++ b/webrtc/stun/stun_transport.nim
@@ -36,7 +36,7 @@ proc addConnToTable(self: Stun, conn: StunConn) =
   proc cleanup() =
     self.connections.del(conn.raddr)
   self.connections[conn.raddr] = conn
-  conn.cleanup = cleanup
+  conn.addOnClose(cleanup)
 
 proc accept*(self: Stun): Future[StunConn] {.async: (raises: [CancelledError]).} =
   ## Accept a Stun Connection

--- a/webrtc/stun/stun_transport.nim
+++ b/webrtc/stun/stun_transport.nim
@@ -32,6 +32,12 @@ type
 
     rng: ref HmacDrbgContext
 
+proc addConnToTable(self: Stun, conn: StunConn) =
+  proc cleanup() =
+    self.connections.del(conn.raddr)
+  self.connections[conn.raddr] = conn
+  conn.cleanup = cleanup
+
 proc accept*(self: Stun): Future[StunConn] {.async: (raises: [CancelledError]).} =
   ## Accept a Stun Connection
   ##
@@ -53,16 +59,8 @@ proc connect*(
   do:
     let res = StunConn.new(self.udp, raddr, false, self.usernameProvider,
       self.usernameChecker, self.passwordProvider, self.rng)
-    self.connections[raddr] = res
+    self.addConnToTable(res)
     return res
-
-proc cleanupStunConn(self: Stun, conn: StunConn) {.async: (raises: []).} =
-  # Waiting for a connection to be closed to remove it from the table
-  try:
-    await conn.join()
-    self.connections.del(conn.raddr)
-  except CancelledError as exc:
-    warn "Error cleaning up Stun Connection", error=exc.msg
 
 proc stunReadLoop(self: Stun) {.async: (raises: [CancelledError]).} =
   while true:
@@ -71,9 +69,8 @@ proc stunReadLoop(self: Stun) {.async: (raises: [CancelledError]).} =
     if not self.connections.hasKey(raddr):
       stunConn = StunConn.new(self.udp, raddr, true, self.usernameProvider,
         self.usernameChecker, self.passwordProvider, self.rng)
-      self.connections[raddr] = stunConn
+      self.addConnToTable(stunConn)
       await self.pendingConn.addLast(stunConn)
-      asyncSpawn self.cleanupStunConn(stunConn)
     else:
       try:
         stunConn = self.connections[raddr]


### PR DESCRIPTION
## Description

Working on SCTP made me aware of one issue which raised another one:
1. When we close a SCTP Connection, the associated DTLS and Stun connections should be closed aswell.
2. By fixing this issue, I realized that StunConn were not properly closed when created using connect (it was not flushed from `Stun.connections` Table)

I fixed those two issues and did a quick rework on how Connections are removed from Table.
Before, a Future was created where I awaited for the end of a connection (using `await conn.join()`) then removed.
Now, `join` is removed, I replaced it by an `onClose` sequence of procedure to be called at the end of closing. It solves another potential issue (a race condition) because while awaiting the future to remove the connection from the Table, you could, in theory, re-create the Connection before it's removed, creating a conflict. 

As a sweet bonus, I removed one `asyncSpawn`

## The two issues in detail
- The first issue  is a design issue.

When an SCTP Connection is closed, the associated DTLS Connection become useless, it must be closed (so I must call await self.conn.close() when closing an SctpConn).
Similarly, when a DTLS Connection is closed, the associated Stun Connection become useless, it must be closed.
I fixed the DTLS one here https://github.com/vacp2p/nim-webrtc/pull/22/files#diff-33ff420ddc6f5b3b2a85d5b5b37dd7947486d2566811812f1183b721dc436852R223 
I'm still working on the SCTP on a separated PR (#11), but I will fix it soon here aswell.

- The second issue is clearly a bug.

When a StunConn is closed, it should be removed from the Stun.connections table which tracks every connections (in order to close them when the StunTransport is stopped).
Everything works fine when a StunConn is accepted (by calling this asyncSpawn https://github.com/vacp2p/nim-webrtc/pull/22/files#diff-634beab93d219ce578020802e038549117aa731afb0eec174477abd09a3d3dddL76)
But when connecting to a new connection I forgot to start the cleanup.
The consequence of this is that a connected StunConn is effectively "closed" if you check the flag but it is still stored in Stun.connections, thus, when trying to re-connect to this specific address, it will return the already closed StunConn instead of creating a new one. https://github.com/vacp2p/nim-webrtc/pull/22/files#diff-634beab93d219ce578020802e038549117aa731afb0eec174477abd09a3d3dddL51-L52 